### PR TITLE
Try to boost trsort on some files

### DIFF
--- a/include/divsufsort_private.h
+++ b/include/divsufsort_private.h
@@ -197,7 +197,7 @@ sssort(const sauchar_t *Td, const saidx_t *PA,
        saidx_t depth, saidx_t n, saint_t lastsuffix);
 /* trsort.c */
 void
-trsort(saidx_t *ISA, saidx_t *SA, saidx_t n, saidx_t depth);
+trsort(saidx_t *ISA, saidx_t *SA, saidx_t n, saidx_t depth, saidx_t *buf, saidx_t bufsize);
 
 
 #ifdef __cplusplus

--- a/lib/divsufsort.c
+++ b/lib/divsufsort.c
@@ -156,9 +156,10 @@ note:
     }
 
     /* Construct the inverse suffix array of type B* suffixes using trsort. */
-    trsort(ISAb, SA, m, 1);
+    buf = ISAb + m, bufsize = n - (2 * m);
+    trsort(ISAb, SA, m, 1, buf, bufsize);
 
-    /* Set the sorted order of tyoe B* suffixes. */
+    /* Set the sorted order of type B* suffixes. */
     for(i = n - 1, j = m, c0 = T[n - 1]; 0 <= i;) {
       for(--i, c1 = c0; (0 <= i) && ((c0 = T[i]) >= c1); --i, c1 = c0) { }
       if(0 <= i) {


### PR DESCRIPTION
1. It decreases the amount of updates of ranks.
2. It decreases the number of comparisons while sorting of first
   and last partitions after tandem repeat partitioning.

It decreases total time for Manzini's corpus by 3% and total time for Gauntlet by 24%
