### PR TITLE
update cmake_minimum_required(VERSION {2.4.4 => 3.25})

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 ### cmake file for building libdivsufsort Package ###
-cmake_minimum_required(VERSION 2.4.4)
+cmake_minimum_required(VERSION 3.25)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 include(AppendCompilerFlags)
 


### PR DESCRIPTION
I don't know anything about cmake, but this fixes the following error for cmake 4, which introduced backwards incompatibility.

```
CMake Error at CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


-- Configuring incomplete, errors occurred!
```

As a workaround, set the `CMAKE_POLICY_MINIMUM_VERSION` environment variable to `3.5`.